### PR TITLE
Fix future type parameter

### DIFF
--- a/lib/redux_future.dart
+++ b/lib/redux_future.dart
@@ -73,7 +73,7 @@ void futureMiddleware<State>(Store<State> store, action, NextDispatcher next) {
 // Dispatches the result of a future to the Store.
 Future<FutureResultAction> _dispatchResults<State>(
   Store<State> store,
-  Future<FutureResultAction> future,
+  Future<dynamic> future,
 ) {
   return future.then((result) {
     final fulfilledAction = new FutureFulfilledAction(result);

--- a/test/redux_future_test.dart
+++ b/test/redux_future_test.dart
@@ -29,7 +29,7 @@ main() {
           middleware: [futureMiddleware],
         );
         final action = new FutureAction(
-          new Future.value("Fetch Complete"),
+          new Future<String>.value("Fetch Complete"),
           initialAction: "Fetching",
         );
 


### PR DESCRIPTION
`_dispatchResults`'s future parameter has type `Future<FutureResultAction>`. It should be `Future<dynamic>`.

The first commit add explicit type for future action to break test, second commit fix it.