### PR TITLE
Initial action dispatch

### DIFF
--- a/lib/redux_future.dart
+++ b/lib/redux_future.dart
@@ -59,7 +59,7 @@ import 'package:redux/redux.dart';
 void futureMiddleware<State>(Store<State> store, action, NextDispatcher next) {
   if (action is FutureAction) {
     if (action.initialAction != null) {
-      next(action.initialAction);
+      store.dispatch(action.initialAction);
     }
 
     _dispatchResults(store, action.future).then(action.completer.complete);

--- a/test/redux_future_test.dart
+++ b/test/redux_future_test.dart
@@ -121,6 +121,33 @@ main() {
           new FutureRejectedAction(exception),
         );
       });
+
+      test('dispatchs initial action through Store.dispatch', () async {
+        List<String> logs = <String>[];
+        void loggingMiddleware<State>(Store<State> store, dynamic action, NextDispatcher next) {
+          logs.add(action.toString());
+          next(action);
+        }
+
+        final store = new Store<String>(
+          futureReducer,
+          middleware: [loggingMiddleware, futureMiddleware],
+        );
+        final action = new FutureAction(
+          new Future.value("Friend"),
+          initialAction: "Hi",
+        );
+
+        store.dispatch(action);
+
+        final fulfilledAction = await action.result;
+
+        expect(logs, <String>[
+          action.toString(),
+          "Hi",
+          fulfilledAction.toString(),
+        ]);
+      });
     });
 
     group('Future', () {


### PR DESCRIPTION
Dispatch initial action through `Store.dispatch` not `NextDispatcher`. This way the initial action can go through all preceding middlewares.

The first commit add tests to break existing code, second commit fix it.